### PR TITLE
Improve window management to automatically apply layouts

### DIFF
--- a/hammerspoon/.hammerspoon/init.lua
+++ b/hammerspoon/.hammerspoon/init.lua
@@ -14,6 +14,12 @@ hs.alert.defaultStyle.radius = 1
 hs.alert.defaultStyle.fadeInDuration = 0
 hs.alert.defaultStyle.fadeOutDuration = 2
 
+-- https://www.hammerspoon.org/docs/hs.ipc.html#cliInstall
+-- https://github.com/Hammerspoon/hammerspoon/issues/2930#issuecomment-899092002
+if not hs.ipc.cliStatus("/opt/homebrew") then
+    hs.ipc.cliInstall("/opt/homebrew")
+end
+
 -- global hotkey prefix key combinations (used in modules)
 HYPER = { "cmd", "ctrl" }
 HYPER_SHIFT = { "cmd", "ctrl", "shift" }
@@ -22,7 +28,9 @@ require("modules.plugins")
 require("modules.alerts")
 require("modules.caffeine")
 require("modules.watchers")
-require("modules.window")
+
+WINDOW_MANAGER = require("modules.window")
+WINDOW_MANAGER:init()
 
 -- Custom Spoons
 

--- a/hammerspoon/.hammerspoon/modules/watchers.lua
+++ b/hammerspoon/.hammerspoon/modules/watchers.lua
@@ -4,17 +4,17 @@
 
 local helpers = require("modules.helpers")
 
-local function application_callback(appName, eventType, app)
-    if eventType == hs.application.watcher.launched then
-        hs.alert.show("Application Launched: " .. appName)
-        while app:mainWindow() == nil do
-            -- app:mainWindow() will be `nil` until fully loaded
-        end
-        app:mainWindow():moveToUnit(hs.layout.maximized)
-    end
-end
-APPLICATION_WATCHER = hs.application.watcher.new(application_callback)
-APPLICATION_WATCHER:start()
+-- local function application_callback(appName, eventType, app)
+--     if eventType == hs.application.watcher.launched then
+--         hs.alert.show("Application Launched: " .. appName)
+--         while app:mainWindow() == nil do
+--             -- app:mainWindow() will be `nil` until fully loaded
+--         end
+--         app:mainWindow():moveToUnit(hs.layout.maximized)
+--     end
+-- end
+-- APPLICATION_WATCHER = hs.application.watcher.new(application_callback)
+-- APPLICATION_WATCHER:start()
 
 local function callback_pathwatcher(files, flagTables)
     local mods = {}

--- a/hammerspoon/.hammerspoon/modules/window.lua
+++ b/hammerspoon/.hammerspoon/modules/window.lua
@@ -1,12 +1,21 @@
---------------------------------------------------------------------------------
---                             Window Management                              --
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------
+--                                                  Window Management                                                  --
+-------------------------------------------------------------------------------------------------------------------------
 
+-- References
 -- https://www.hammerspoon.org/go/#winlayout
 -- https://www.hammerspoon.org/Spoons/WindowHalfsAndThirds.html
 -- https://www.hammerspoon.org/Spoons/WindowScreenLeftAndRight.html
 
-hs.window.animationDuration = 0
+local obj = {}
+obj.__index = obj
+
+obj.name = "Window Management"
+obj.version = "1.0.0"
+
+-------------------------------------------------------------------------------------------------------------------------
+--                                                       Helpers                                                       --
+-------------------------------------------------------------------------------------------------------------------------
 
 CENTER_60 = hs.geometry({ x = 0.3, y = 0.0, w = 0.4, h = 1.0 })
 CENTER_66 = hs.geometry({ x = 0.1666, y = 0, w = 0.6666, h = 1 })
@@ -102,32 +111,56 @@ local function twoDisplayLayout()
     hs.layout.apply(layout)
 end
 
-spoon.SpoonInstall:andUse("WindowScreenLeftAndRight", {
-    hotkeys = {
-        screen_left = { { "control", "cmd" }, "Left" },
-        screen_right = { { "control", "cmd" }, "Right" },
-    },
-})
+-- enumeration of possible window layouts
+local CENTERED, PRIMARY, SECONDARY = 1, 2, 3
 
-spoon.SpoonInstall:andUse("WindowHalfsAndThirds", {
-    hotkeys = {
-        third_left = { { "cmd" }, "Left" },
-        left_half = { { "cmd", "shift" }, "Left" },
-        third_right = { { "cmd" }, "Right" },
-        right_half = { { "cmd", "shift" }, "Right" },
-        max_toggle = { { "cmd", "shift" }, "Up" },
-        center = { { "cmd" }, "Up" },
-    },
-})
+-------------------------------------------------------------------------------------------------------------------------
+--                                                       Module                                                        --
+-------------------------------------------------------------------------------------------------------------------------
 
-hs.hotkey.bind({ "cmd", "ctrl" }, "1", function()
-    hs.layout.apply(LAYOUT_PRIMARY)
-end)
+local function application_callback(app_name, event_type, app)
+    if event_type == hs.application.watcher.launched then
+        hs.alert("Launched " .. app_name)
 
-hs.hotkey.bind({ "cmd", "ctrl" }, "2", function()
-    hs.layout.apply(LAYOUT_CENTERED)
-end)
+        while app:mainWindow() == nil do
+            -- app:mainWindow() will be `nil` until fully loaded
+        end
 
-hs.hotkey.bind({ "cmd", "ctrl" }, "3", function()
-    hs.layout.apply(LAYOUT_SECONDARY)
-end)
+        if obj.layout == CENTERED then
+            app:mainWindow():moveToUnit(CENTER_66)
+        elseif obj.layout == PRIMARY then
+            app:mainWindow():moveToUnit(RIGHT_70)
+        elseif obj.layout == SECONDARY then
+            app:mainWindow():moveToUnit(CENTER_60)
+        end
+    end
+end
+
+-- Initialize window layout state, and setup application watcher
+function obj:init()
+    -- set default window layout
+    self.layout = CENTERED
+
+    -- initialize application watcher to automatically apply layout to new windows
+    self.application_watcher = hs.application.watcher.new(application_callback)
+    self.application_watcher:start()
+    hs.window.animationDuration = 0
+
+
+    hs.hotkey.bind({ "cmd", "ctrl" }, "1", function()
+        self.layout = PRIMARY
+        hs.layout.apply(LAYOUT_PRIMARY)
+    end)
+
+    hs.hotkey.bind({ "cmd", "ctrl" }, "2", function()
+        self.layout = CENTERED
+        hs.layout.apply(LAYOUT_CENTERED)
+    end)
+
+    hs.hotkey.bind({ "cmd", "ctrl" }, "3", function()
+        self.layout = SECONDARY
+        hs.layout.apply(LAYOUT_SECONDARY)
+    end)
+end
+
+return obj


### PR DESCRIPTION
Add watcher with callback that automatically applies the current layout
to launched windows. Refactor the window management module to be more
object-oriented to better handle state management.