### PR TITLE
fix: validate stow restores before applying

### DIFF
--- a/_restore.sh
+++ b/_restore.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1004
+set -euo pipefail
 
 ASCII_STOW='
       ___           ___           ___           ___
@@ -18,11 +19,20 @@ ASCII_STOW='
 
 echo "$ASCII_STOW"
 
+if ! command -v stow >/dev/null 2>&1; then
+    echo "[ERROR] GNU Stow is required. Run ./_install.sh first."
+    exit 1
+fi
+
 for file in *; do
     if [ -d "$file" ]; then
         read -r -e -p "[y/N] - Restore ${file}? " response
         if [[ "$response" == [Yy]* ]]; then
-            stow -t "$HOME" "$file"
+            if stow -n -v -t "$HOME" "$file"; then
+                stow -v -t "$HOME" "$file"
+            else
+                echo "[ERROR] Stow dry-run failed for ${file}; skipping."
+            fi
         fi
     fi
 done


### PR DESCRIPTION
## Summary
- enable safer shell execution settings for restore
- fail early when GNU Stow is unavailable
- run a verbose stow dry-run before applying each selected package
- skip packages whose dry-run reports conflicts

## Test
- bash -n _restore.sh