### PR TITLE
feat: add shell pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.27.2
     hooks:
@@ -29,3 +25,13 @@ repos:
         entry: shfmt -d
         language: system
         types: [shell]
+      - id: ruff-check
+        name: ruff check
+        entry: uvx ruff check
+        language: system
+        types: [python]
+      - id: ty-check
+        name: ty check
+        entry: uvx ty check
+        language: system
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,31 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 22.3.0
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
-    -   id: black
--   repo: https://github.com/zricethezav/gitleaks
-    rev: v8.2.0
+      - id: black
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
     hooks:
-    -   id: gitleaks
-- repo: https://github.com/JohnnyMorganz/StyLua
-  rev: v0.20.0
-  hooks:
-    - id: stylua-system
+      - id: gitleaks
+  - repo: https://github.com/JohnnyMorganz/StyLua
+    rev: v2.1.0
+    hooks:
+      - id: stylua-system
+  - repo: local
+    hooks:
+      - id: bash-syntax
+        name: bash syntax check
+        entry: bash -n
+        language: system
+        types: [shell]
+      - id: shfmt
+        name: shfmt
+        entry: shfmt -d
+        language: system
+        types: [shell]

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-.PHONY: help
+.PHONY: help lint
 
 help:
 	@echo "restore   - Restore configuration files via \`stow\`"
 	@echo "install   - Install platform-dependant packages and dependencies"
 	@echo "configure - Set system-wide configurations and settings"
+	@echo "lint      - Run pre-commit checks across the repository"
+
+lint:
+	pre-commit run --all-files
 
 restore:
 	./_restore.sh


### PR DESCRIPTION
## Summary
- update existing pre-commit hook revisions
- add local bash syntax and shfmt checks for shell files
- replace Black with Astral tooling for Python: ruff check and ty check via uvx
- explicitly run StyLua with the repository .stylua.toml config
- add a Makefile lint target that runs pre-commit across the repository

## Test
- pre-commit run check-yaml --files .pre-commit-config.yaml
- pre-commit run stylua-system --files hammerspoon/.hammerspoon/init.lua
- pre-commit run ruff-check --files .github/daily-git-stats.py
- pre-commit run ty-check --files .github/daily-git-stats.py